### PR TITLE
Review error message.

### DIFF
--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/broker/Topic.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/broker/Topic.java
@@ -5,12 +5,12 @@ package com.lightbend.lagom.javadsl.api.broker;
 
 /**
  * A topic can be used to publish/subscribe messages to/from a message broker.
- * 
- * @param <Message> The message type.
+ *
+ * @param <TopicMessageType> The message type.
  *
  * Note: This class is not meant to be extended by client code.
  */
-public interface Topic<Message> {
+public interface Topic<TopicMessageType> {
 
   /**
    * The topic identifier.
@@ -22,7 +22,7 @@ public interface Topic<Message> {
    * Obtain a subscriber to this topic.
    * @return A Subscriber to this topic.
    */
-  Subscriber<Message> subscribe();
+  Subscriber<TopicMessageType> subscribe();
 
   /**
    * A topic identifier.

--- a/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceCallResolver.scala
+++ b/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceCallResolver.scala
@@ -48,7 +48,7 @@ abstract class CallResolver(
       case param: ParameterizedType if param.getRawType == classOf[Source[_, _]] =>
         val messageType = param.getActualTypeArguments()(0)
         Some(new UnresolvedStreamedMessageSerializer[Any](messageType).asInstanceOf[MessageSerializer[T, _]])
-      case typeVariable: TypeVariable[_] => throw new IllegalArgumentException(s"Illegal use of type variable <${typeVariable.getName}> in message type.")
+      case typeVariable: TypeVariable[_] => throw new IllegalArgumentException(s"Unspecified type variable <${typeVariable.getName}> in message type.")
       case _                             => None
     }
   }
@@ -57,7 +57,7 @@ abstract class CallResolver(
     messageSerializers.get(messageType).asInstanceOf[Option[MessageSerializer[T, _]]] orElse {
       messageType match {
         case param: ParameterizedType      => registeredMessageSerializerFor[T](param.getRawType)
-        case typeVariable: TypeVariable[_] => throw new IllegalArgumentException(s"Illegal use of type variable <${typeVariable.getName}> in message type.")
+        case typeVariable: TypeVariable[_] => throw new IllegalArgumentException(s"Unspecified type variable <${typeVariable.getName}> in message type.")
         case _                             => None
       }
     }

--- a/service/javadsl/api/src/test/java/com/lightbend/lagom/api/mock/MissingTopicTypeService.java
+++ b/service/javadsl/api/src/test/java/com/lightbend/lagom/api/mock/MissingTopicTypeService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.api.mock;
+
+import com.lightbend.lagom.javadsl.api.Descriptor;
+import com.lightbend.lagom.javadsl.api.Service;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
+import com.lightbend.lagom.javadsl.api.broker.Topic;
+import com.lightbend.lagom.javadsl.api.transport.Method;
+
+import static com.lightbend.lagom.javadsl.api.Service.named;
+import static com.lightbend.lagom.javadsl.api.Service.restCall;
+
+public interface MissingTopicTypeService extends Service {
+    Topic myTopic();
+
+    @Override
+    default Descriptor descriptor() {
+        return named("/missing-topic-type")
+            .withTopics(Service.topic("topicName", this::myTopic));
+    }
+}

--- a/service/javadsl/api/src/test/scala/com/lightbend/lagom/internal/api/ServiceReaderSpec.scala
+++ b/service/javadsl/api/src/test/scala/com/lightbend/lagom/internal/api/ServiceReaderSpec.scala
@@ -152,6 +152,17 @@ class ServiceReaderSpec extends WordSpec with Matchers with Inside {
       exception.getMessage should include("<Foo>")
     }
 
+    "fail to read a Java service descriptor from a public interface because a the topic type is missing" in {
+      val exception = intercept[IllegalMessageTypeException] {
+        serviceDescriptor[MissingTopicTypeService]
+      }
+
+      // When users don't set a Topic type, <Message> is the type of the topic:
+      //     Topic  myMethod();
+      // because <Message> is the unbound type used in Service#topic(). See com.lightbend.lagom.javadsl.api.Service
+      exception.getMessage should include("<TopicMessageType>")
+    }
+
   }
 
   def serviceDescriptor[S <: Service](implicit ct: ClassTag[S]) = {


### PR DESCRIPTION
Reviews the error message.

Renames Topic's default type placeholder.

Adds test for Topic which also tests missing type (as opposed to service call tests which tested user-provided types). It's all the same but, meh.